### PR TITLE
fix: JWT permission issues

### DIFF
--- a/src/components/TariConnectorButton.tsx
+++ b/src/components/TariConnectorButton.tsx
@@ -22,8 +22,8 @@ function TariConnectorButton({
   background = '#9330FF',
   textColor = '#FFFFFF',
   onOpen,
-  permissions,
-  optional_permissions,
+  permissions = new TariPermissions(),
+  optional_permissions = new TariPermissions(),
   signalingServer,
   rtcConfig
 }: TariConnectorButtonProps) {
@@ -33,11 +33,14 @@ function TariConnectorButton({
   const [tokenUrl, setTokenUrl] = useState("");
   const [tari, setTari] = useState<any>();
   // console.log('onOpen', onOpen);
+  const all_permissions = new TariPermissions();
+  all_permissions.addPermissions(permissions);
+  all_permissions.addPermissions(optional_permissions);
 
   const openPopup = () => {
     setIsOpen(true);
     setFadeClass('tariFadeIn');
-    initTariConnection(signalingServer, rtcConfig).then((tari) => {
+    initTariConnection(all_permissions, signalingServer, rtcConfig).then((tari) => {
       setTari(tari);
       onOpen?.(tari);
       if (tari.token) {

--- a/src/tari_permissions.tsx
+++ b/src/tari_permissions.tsx
@@ -170,6 +170,14 @@ export class TariPermissionAccountBalance {
     return { "AccountBalance": this.value }
   }
 }
+
+export class TariPermissionAccountInfo {
+  constructor() {}
+  toJSON() {
+    return "AccountInfo"
+  }
+}
+
 export class TariPermissionAccountList {
   private value?: ComponentAddress | null;
   constructor(value?: ComponentAddress) {
@@ -188,13 +196,24 @@ export class TariPermissionAccountList {
     }
   }
 }
+export class TariPermissionTransactionGet {
+  constructor() {}
+  toJSON() {
+    return "TransactionGet"
+  }
+}
 export class TariPermissionTransactionSend {
-  private value: SubstateAddress;
-  constructor(value: SubstateAddress) {
+  private value?: SubstateAddress;
+  constructor(value?: SubstateAddress) {
     this.value = value;
   }
   toJSON() {
-    return { "TransactionSend": this.value }
+    console.log('JSON TariPermissionTransactionSend', this.value)
+    if (this.value === undefined) {
+      return { "TransactionSend": null }
+    } else {
+      return { "TransactionSend": this.value }
+    }
   }
 }
 
@@ -220,7 +239,7 @@ export class TariPermissionNftGetOwnershipProof {
   }
 }
 
-export type TariPermission = TariPermissionNftGetOwnershipProof | TariPermissionAccountBalance | TariPermissionAccountList | TariPermissionTransactionSend | TariPermissionGetNft;
+export type TariPermission = TariPermissionNftGetOwnershipProof | TariPermissionAccountBalance | TariPermissionAccountInfo | TariPermissionAccountList | TariPermissionTransactionGet | TariPermissionTransactionSend | TariPermissionGetNft;
 
 export class TariPermissions {
   private permissions: TariPermission[];
@@ -231,6 +250,10 @@ export class TariPermissions {
 
   addPermission(permission: TariPermission) {
     this.permissions.push(permission);
+  }
+
+  addPermissions(other: TariPermissions) {
+    this.permissions.push(...other.permissions);
   }
 
   toJSON() {

--- a/src/webrtc.tsx
+++ b/src/webrtc.tsx
@@ -1,3 +1,5 @@
+import { TariPermissions } from "./tari_permissions";
+
 class SignaligServer {
   private _token?: string;
   private _server_url: string
@@ -10,8 +12,8 @@ class SignaligServer {
     }
   }
 
-  async initToken() {
-    this._token = await this.authLogin()
+  async initToken(permissions: TariPermissions) {
+    this._token = await this.authLogin(permissions)
   }
 
   public get token() {
@@ -46,8 +48,8 @@ class SignaligServer {
     return json.result;
   }
 
-  private async authLogin() {
-    return await this.jsonRpc("auth.login");
+  private async authLogin(permissions: TariPermissions) {
+    return await this.jsonRpc("auth.login", undefined, permissions);
   }
 
   async storeIceCandidate(ice_candidate: RTCIceCandidate) {
@@ -91,8 +93,8 @@ export class TariConnection {
     return this._signalingServer.token;
   }
 
-  async init() {
-    await this._signalingServer.initToken();
+  async init(permissions: TariPermissions) {
+    await this._signalingServer.initToken(permissions);
     // Setup our receiving end
     this._dataChannel.onmessage = (message) => {
       let response = JSON.parse(message.data)
@@ -201,9 +203,9 @@ export class TariConnection {
   }
 }
 
-async function initTariConnection(signalig_server_url?: string, config?: RTCConfiguration) {
+async function initTariConnection(permissions: TariPermissions, signalig_server_url?: string, config?: RTCConfiguration) {
   let tari = new TariConnection(signalig_server_url, config);
-  await tari.init();
+  await tari.init(permissions);
   return tari;
 }
 


### PR DESCRIPTION
Description
---
* Propagate the user accepted permissions to the signaling server
* Adapt to the new permission types for transactions and account info

Motivation and Context
---
Up until now on web applications that use the `tari-connector` project to interact with a wallet daemon, the tokens being generated did not work. https://github.com/tari-project/tari-dan/pull/549 is the corresponding PR in the `tari-dan` side.

How Has This Been Tested?
---
Manually using a web application that uses the `tari-connector` to interact with the wallet daemon

What process can a PR reviewer use to test or verify this change?
---
Manually use a web application that uses the `tari-connector` to interact with the wallet daemon