### PR TITLE
fix: ice candidates double parse

### DIFF
--- a/src/webrtc.tsx
+++ b/src/webrtc.tsx
@@ -154,7 +154,7 @@ export class TariConnection {
     // We add all the ice candidates to connect, the other end is doing the same with our ice candidates
     iceCandidates = JSON.parse(iceCandidates);
     for (const iceCandidate of iceCandidates) {
-      this._peerConnection.addIceCandidate(JSON.parse(iceCandidate));
+      this._peerConnection.addIceCandidate(iceCandidate);
     }
   }
 


### PR DESCRIPTION
The ice candidates were parsed and then each ice candidates tried to be parsed again (that was triggering exception)