### PR TITLE
feat: new permission for public key listing

### DIFF
--- a/src/tari_permissions.tsx
+++ b/src/tari_permissions.tsx
@@ -196,6 +196,14 @@ export class TariPermissionAccountList {
     }
   }
 }
+
+export class TariPermissionKeyList {
+  constructor() {}
+  toJSON() {
+    return "KeyList"
+  }
+}
+
 export class TariPermissionTransactionGet {
   constructor() {}
   toJSON() {
@@ -239,7 +247,7 @@ export class TariPermissionNftGetOwnershipProof {
   }
 }
 
-export type TariPermission = TariPermissionNftGetOwnershipProof | TariPermissionAccountBalance | TariPermissionAccountInfo | TariPermissionAccountList | TariPermissionTransactionGet | TariPermissionTransactionSend | TariPermissionGetNft;
+export type TariPermission = TariPermissionNftGetOwnershipProof | TariPermissionAccountBalance | TariPermissionAccountInfo | TariPermissionAccountList | TariPermissionKeyList | TariPermissionTransactionGet | TariPermissionTransactionSend | TariPermissionGetNft;
 
 export class TariPermissions {
   private permissions: TariPermission[];


### PR DESCRIPTION
In the context of atomic swaps, and in general in any web that may result in the user creating a new account, we want to be able to list all the public keys of the wallet.

The public key list also indicates which key is the default key, so that we can use it in the web interface to predict the component address of the newly created user account.

This PR adds the representation for the new type of permission (`TariPermissionKeyList`) needed for public key listing.

There is a [corresponding PR](https://github.com/tari-project/tari-dan/pull/647) in the `tari-dan` repository