### PR TITLE
feat: implement signaling server polling 

### DIFF
--- a/examples/material-vite-ts/src/App.tsx
+++ b/examples/material-vite-ts/src/App.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import { Button, Box, Link, Typography, Container } from '@mui/material';
+import { Box, Typography, Container } from '@mui/material';
 import { TariConnection, TariConnectorButton } from 'tari-connector/src/index';
 import {
 	ResourceAddress,
 	Hash,
-	TariPermissionNftGetOwnershipProof,
 	TariPermissions,
 	TariPermissionAccountBalance,
 	TariPermissionAccountList,
 	SubstateAddress,
-	NonFungibleIndexAddress,
 	NonFungibleAddress,
 	NonFungibleAddressContents,
 	NonFungibleId,
@@ -39,8 +37,8 @@ function Connector() {
 		setTari(tari);
 		window.tari = tari;
 	};
-	const setAnswer = () => {
-		tari?.setAnswer();
+	const onConnection = () => {
+		console.log("Connected to the wallet daemon");
 	};
 	let address = import.meta.env.VITE_SIGNALING_SERVER_ADDRESS || "http://localhost:9100";
 	let permissions = new TariPermissions();
@@ -65,8 +63,8 @@ function Connector() {
 				permissions={permissions}
 				optional_permissions={optional_permissions}
 				onOpen={onOpen}
+				onConnection={onConnection}
 			/>
-			{tari ? <button onClick={setAnswer}>SetAnswer</button> : null}
 		</>
 	);
 }

--- a/src/components/TariConnectorButton.tsx
+++ b/src/components/TariConnectorButton.tsx
@@ -11,6 +11,7 @@ export interface TariConnectorButtonProps {
   background?: string;
   textColor?: string;
   onOpen?: (tari: TariConnection) => void;
+  onConnection?: () => void;
   permissions?: TariPermissions,
   optional_permissions?: TariPermissions,
   signalingServer?: string,
@@ -23,6 +24,7 @@ function TariConnectorButton({
   background = '#9330FF',
   textColor = '#FFFFFF',
   onOpen,
+  onConnection,
   permissions = new TariPermissions(),
   optional_permissions = new TariPermissions(),
   signalingServer,
@@ -42,7 +44,7 @@ function TariConnectorButton({
   const openPopup = () => {
     setIsOpen(true);
     setFadeClass('tariFadeIn');
-    initTariConnection(all_permissions, signalingServer, rtcConfig).then((tari) => {
+    initTariConnection(all_permissions, signalingServer, rtcConfig, onConnection).then((tari) => {
       setTari(tari);
       onOpen?.(tari);
       if (tari.token) {


### PR DESCRIPTION
Up until now, users had to manually click (or the web developers had to implement a polling) on a button to call the `setAnswer` method, that tries to set up the webRTC peer connection.

This PR implements a polling on the `tari-connector` itself, so after the user clicks on the connection button (and the QR is shown) every 2 seconds it tries to call `setAnswer` until the connection is established.

Web developers need to implement a new `onConnection` callback that will be called by the `tari-connector` once the WebRTC connection with the wallet (and the wallet JWT) is ready.